### PR TITLE
Don't `return()` from a magrittr pipe

### DIFF
--- a/R/best_swaps.R
+++ b/R/best_swaps.R
@@ -28,9 +28,10 @@ mat_swap_n_more <- function(mat, mat_orig, n, frame_weights, frame_balls,
     rep(seq_along(.), times = .) %>%
     {
       if (length(.) <= 1) {
-        return(.)
+        .
+      } else {
+        sample(.)
       }
-      sample(.)
     }
   winner_frames <- plyr::count(frames_getting) %>%
     dplyr::rename(frame = "x", amount = "freq")

--- a/R/detrend.R
+++ b/R/detrend.R
@@ -159,9 +159,10 @@ img_detrend_swaps_specified <- function(arr3d, swaps) {
     rep(seq_along(.), times = .) %>%
     {
       if (length(.) <= 1) {
-        return(.)
+        .
+      } else {
+        sample(.)
       }
-      sample(.)
     }
   if (length(px_getting)) {
     elems_getting <- cbind(px_getting, frames_getting) %>%


### PR DESCRIPTION
Hello,

We've rewritten magrittr in C to fix some of the longstanding overhead issue (especially for `traceback()`). One consequence of this rewrite is that `return()` no longer works. It was kind of undefined behaviour to begin with (does it return from the current pipe expression? from the enclosing function? from the pipeline?).

We're planning to send magrittr to CRAN in one month. It would be great if you could update detrendr with this fix before then :)